### PR TITLE
nvme-cli updates on top of Stuart's work

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -803,7 +803,7 @@ int nvmf_discover(const char *desc, int argc, char **argv, bool connect)
 		OPT_FLAG("force",          0, &force,         "Force persistent discovery controller creation"),
 		OPT_FLAG("nbft",           0, &nbft,          "Only look at NBFT tables"),
 		OPT_FLAG("no-nbft",        0, &nonbft,        "Do not look at NBFT tables"),
-		OPT_STRING("nbft-path",   'N', "STR", &nbft_path, "user-defined path for NBFT tables"),
+		OPT_STRING("nbft-path",  0, "STR", &nbft_path, "user-defined path for NBFT tables"),
 		OPT_END()
 	};
 

--- a/nbft.c
+++ b/nbft.c
@@ -1,23 +1,4 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-/*
- * nbft.c
- *
- * Copyright (c) 2021-2022, Dell Inc. or its subsidiaries.  All Rights Reserved.
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
 
 #include <errno.h>
 #include <stdio.h>
@@ -130,12 +111,10 @@ int discover_from_nbft(nvme_root_t r, char *hostnqn_arg, char *hostid_arg,
 
 				if (hostid_arg)
 					hostid = hostid_arg;
-				else {
-					if (*entry->nbft->host.id) {
-						hostid = (char *)util_uuid_to_string(entry->nbft->host.id);
-						if (!hostid)
-							hostid = hostid_sys;
-					}
+				else if (*entry->nbft->host.id) {
+					hostid = (char *)util_uuid_to_string(entry->nbft->host.id);
+					if (!hostid)
+						hostid = hostid_sys;
 				}
 
 				h = nvme_lookup_host(r, hostnqn, hostid);
@@ -184,8 +163,8 @@ int discover_from_nbft(nvme_root_t r, char *hostnqn_arg, char *hostid_arg,
 				/*
 				 * With TCP/DHCP, it can happen that the OS
 				 * obtains a different local IP address than the
-				 * firwmare had. Retry without host_traddr.
-				*/
+				 * firmware had. Retry without host_traddr.
+				 */
 				if (ret == -1 && errno == ENVME_CONNECT_WRITE &&
 				    !strcmp((*ss)->transport, "tcp") &&
 				    strlen(hfi->tcp_info.dhcp_server_ipaddr) > 0) {

--- a/nbft.h
+++ b/nbft.h
@@ -1,23 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0-or-later
-/*
- * nbft.h
- *
- * Copyright (c) 2021-2022, Dell Inc. or its subsidiaries.  All Rights Reserved.
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 
 #include <ccan/list/list.h>
 
@@ -36,5 +17,3 @@ extern int discover_from_nbft(nvme_root_t r, char *hostnqn_arg, char *hostid_arg
 			      const char *desc, bool connect,
 			      const struct nvme_fabrics_config *cfg, char *nbft_path,
 			      enum nvme_print_flags flags, bool verbose);
-
-//extern int show_nbft(const char *desc, int argc, char **argv);

--- a/plugins/nbft/nbft-plugin.c
+++ b/plugins/nbft/nbft-plugin.c
@@ -551,7 +551,7 @@ int show_nbft(int argc, char **argv, struct command *cmd, struct plugin *plugin)
 		OPT_FLAG("subsystem", 's', &show_subsys, "show NBFT subsystems"),
 		OPT_FLAG("hfi", 'H', &show_hfi, "show NBFT HFIs"),
 		OPT_FLAG("discovery", 'd', &show_discovery, "show NBFT discovery controllers"),
-		OPT_STRING("nbft-path", 'P', "STR", &nbft_path, "user-defined path for NBFT tables"),
+		OPT_STRING("nbft-path", 0, "STR", &nbft_path, "user-defined path for NBFT tables"),
 		OPT_END()
 	};
 

--- a/plugins/nbft/nbft-plugin.c
+++ b/plugins/nbft/nbft-plugin.c
@@ -219,7 +219,22 @@ static json_object *discovery_to_json(struct nbft_info_discovery *disc)
 		return disc_json;
 }
 
-static struct json_object *nbft_to_json(struct nbft_info *nbft, bool show_subsys, bool show_hfi, bool show_discovery)
+static const char *primary_admin_host_flag_to_str(unsigned int primary)
+{
+	static const char * const str[] = {
+		[NBFT_INFO_PRIMARY_ADMIN_HOST_FLAG_NOT_INDICATED] =	"not indicated",
+		[NBFT_INFO_PRIMARY_ADMIN_HOST_FLAG_UNSELECTED] =	"unselected",
+		[NBFT_INFO_PRIMARY_ADMIN_HOST_FLAG_SELECTED] =		"selected",
+		[NBFT_INFO_PRIMARY_ADMIN_HOST_FLAG_RESERVED] =		"reserved",
+	};
+
+	if (primary > NBFT_INFO_PRIMARY_ADMIN_HOST_FLAG_RESERVED)
+		return "INVALID";
+	return str[primary];
+}
+
+static struct json_object *nbft_to_json(struct nbft_info *nbft, bool show_subsys,
+					bool show_hfi, bool show_discovery)
 {
 	struct json_object *nbft_json, *host_json;
 
@@ -244,9 +259,7 @@ static struct json_object *nbft_to_json(struct nbft_info *nbft, bool show_subsys
 	json_object_add_value_int(host_json, "host_nqn_configured",
 				  nbft->host.host_nqn_configured);
 	json_object_add_value_string(host_json, "primary_admin_host_flag",
-				     nbft->host.primary == NBFT_INFO_PRIMARY_ADMIN_HOST_FLAG_NOT_INDICATED ? "not indicated" :
-				     nbft->host.primary == NBFT_INFO_PRIMARY_ADMIN_HOST_FLAG_UNSELECTED ? "unselected" :
-				     nbft->host.primary == NBFT_INFO_PRIMARY_ADMIN_HOST_FLAG_SELECTED ? "selected" : "reserved");
+				     primary_admin_host_flag_to_str(nbft->host.primary));
 	if (json_object_object_add(nbft_json, "host", host_json)) {
 		json_free_object(host_json);
 		goto fail;

--- a/plugins/nbft/nbft-plugin.c
+++ b/plugins/nbft/nbft-plugin.c
@@ -386,15 +386,15 @@ static void print_nbft_hfi_info(struct nbft_info *nbft)
 	}
 
 	printf("\nNBFT HFIs:\n\n");
-	printf("%-3.3s %-4.4s %-10.10s %-17.17s %-4.4s %-*.*s %-4.4s %-*.*s %-*.*s\n",
+	printf("%-3.3s|%-4.4s|%-10.10s|%-17.17s|%-4.4s|%-*.*s|%-4.4s|%-*.*s|%-*.*s\n",
 	       "Idx", "Trsp", "PCI Addr", "MAC Addr", "DHCP",
 	       ip_width, ip_width, "IP Addr", "Mask",
 	       gw_width, gw_width, "Gateway", dns_width, dns_width, "DNS");
-	printf("%-.3s %-.4s %-.10s %-.17s %-.4s %-.*s %-.4s %-.*s %-.*s\n",
+	printf("%-.3s+%-.4s+%-.10s+%-.17s+%-.4s+%-.*s+%-.4s+%-.*s+%-.*s\n",
 	       dash, dash, dash, dash, dash, ip_width, dash, dash,
 	       gw_width, dash, dns_width, dash);
 	for (hfi = nbft->hfi_list; *hfi; hfi++)
-		printf("%-3d %-4.4s %-10.10s %-17.17s %-4.4s %-*.*s %-4d %-*.*s %-*.*s\n",
+		printf("%-3d|%-4.4s|%-10.10s|%-17.17s|%-4.4s|%-*.*s|%-4d|%-*.*s|%-*.*s\n",
 		       (*hfi)->index,
 		       (*hfi)->transport,
 		       pci_sbdf_to_string((*hfi)->tcp_info.pci_sbdf),
@@ -427,11 +427,11 @@ static void print_nbft_discovery_info(struct nbft_info *nbft)
 	}
 
 	printf("\nNBFT Discovery Controllers:\n\n");
-	printf("%-3.3s %-*.*s %-*.*s\n", "Idx", uri_width, uri_width, "URI",
+	printf("%-3.3s|%-*.*s|%-*.*s\n", "Idx", uri_width, uri_width, "URI",
 	       nqn_width, nqn_width, "NQN");
-	printf("%-.3s %-.*s %-.*s\n", dash, uri_width, dash, nqn_width, dash);
+	printf("%-.3s+%-.*s+%-.*s\n", dash, uri_width, dash, nqn_width, dash);
 	for (disc = nbft->discovery_list; *disc; disc++)
-		printf("%-3d %-*.*s %-*.*s\n", (*disc)->index,
+		printf("%-3d|%-*.*s|%-*.*s\n", (*disc)->index,
 		       uri_width, uri_width, (*disc)->uri,
 		       nqn_width, nqn_width, (*disc)->nqn);
 }
@@ -489,16 +489,16 @@ static void print_nbft_subsys_info(struct nbft_info *nbft)
 	}
 
 	printf("\nNBFT Subsystems:\n\n");
-	printf("%-3.3s %-*.*s %-4.4s %-*.*s %-5.5s %-*.*s\n",
+	printf("%-3.3s|%-*.*s|%-4.4s|%-*.*s|%-5.5s|%-*.*s\n",
 	       "Idx", nqn_width, nqn_width, "NQN",
 	       "Trsp", adr_width, adr_width, "Address", "SvcId", hfi_width, hfi_width, "HFIs");
-	printf("%-.3s %-.*s %-.4s %-.*s %-.5s %-.*s\n",
+	printf("%-.3s+%-.*s+%-.4s+%-.*s+%-.5s+%-.*s\n",
 	       dash, nqn_width, dash, dash, adr_width, dash, dash, hfi_width, dash);
 	for (ss = nbft->subsystem_ns_list; *ss; ss++) {
 		char hfi_buf[HFIS_LEN];
 
 		print_hfis(*ss, hfi_buf);
-		printf("%-3d %-*.*s %-4.4s %-*.*s %-5.5s %-*.*s\n",
+		printf("%-3d|%-*.*s|%-4.4s|%-*.*s|%-5.5s|%-*.*s\n",
 		       (*ss)->index, nqn_width, nqn_width, (*ss)->subsys_nqn,
 		       (*ss)->transport, adr_width, adr_width, (*ss)->traddr,
 		       (*ss)->trsvcid, hfi_width, hfi_width, hfi_buf);

--- a/plugins/nbft/nbft-plugin.c
+++ b/plugins/nbft/nbft-plugin.c
@@ -1,23 +1,4 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-/*
- * nbft.c
- *
- * Copyright (c) 2021-2022, Dell Inc. or its subsidiaries.  All Rights Reserved.
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
 
 #include <errno.h>
 #include <stdio.h>
@@ -334,7 +315,8 @@ fail:
 	return NULL;
 }
 
-static int json_show_nbfts(struct list_head *nbft_list, bool show_subsys, bool show_hfi, bool show_discovery)
+static int json_show_nbfts(struct list_head *nbft_list, bool show_subsys,
+			   bool show_hfi, bool show_discovery)
 {
 	struct json_object *nbft_json_array, *nbft_json;
 	struct nbft_file_entry *entry;
@@ -368,7 +350,7 @@ static void print_nbft_hfi_info(struct nbft_info *nbft)
 	unsigned int ip_width = 8, gw_width = 8, dns_width = 8;
 
 	hfi = nbft->hfi_list;
-	if (!hfi || ! *hfi)
+	if (!hfi || !*hfi)
 		return;
 
 	for (; *hfi; hfi++) {
@@ -412,7 +394,7 @@ static void print_nbft_discovery_info(struct nbft_info *nbft)
 	unsigned int nqn_width = 20, uri_width = 12;
 
 	disc = nbft->discovery_list;
-	if (!disc || ! *disc)
+	if (!disc || !*disc)
 		return;
 
 	for (; *disc; disc++) {
@@ -472,7 +454,7 @@ static void print_nbft_subsys_info(struct nbft_info *nbft)
 	unsigned int nqn_width = 20, adr_width = 8, hfi_width = 4;
 
 	ss = nbft->subsystem_ns_list;
-	if (!ss || ! *ss)
+	if (!ss || !*ss)
 		return;
 	for (; *ss; ss++) {
 		size_t len;
@@ -505,13 +487,14 @@ static void print_nbft_subsys_info(struct nbft_info *nbft)
 	}
 }
 
-static void normal_show_nbft(struct nbft_info *nbft, bool show_subsys, bool show_hfi, bool show_discovery)
+static void normal_show_nbft(struct nbft_info *nbft, bool show_subsys,
+			     bool show_hfi, bool show_discovery)
 {
 	printf("%s:\n", nbft->filename);
-	if ((!nbft->hfi_list || ! *nbft->hfi_list) &&
-	    (!nbft->security_list || ! *nbft->security_list) &&
-	    (!nbft->discovery_list || ! *nbft->discovery_list) &&
-	    (!nbft->subsystem_ns_list || ! *nbft->subsystem_ns_list))
+	if ((!nbft->hfi_list || !*nbft->hfi_list) &&
+	    (!nbft->security_list || !*nbft->security_list) &&
+	    (!nbft->discovery_list || !*nbft->discovery_list) &&
+	    (!nbft->subsystem_ns_list || !*nbft->subsystem_ns_list))
 		printf("(empty)\n");
 	else {
 		if (show_subsys)
@@ -523,7 +506,8 @@ static void normal_show_nbft(struct nbft_info *nbft, bool show_subsys, bool show
 	}
 }
 
-static void normal_show_nbfts(struct list_head *nbft_list, bool show_subsys, bool show_hfi, bool show_discovery)
+static void normal_show_nbfts(struct list_head *nbft_list, bool show_subsys,
+			      bool show_hfi, bool show_discovery)
 {
 	bool not_first = false;
 	struct nbft_file_entry *entry;


### PR DESCRIPTION
- remove short options for `--nbft-path`
- style fixes
- improvements for the "normal" output format.

In particular, the output width is strongly reduced now by determining actual field width.

Example:
```
NBFT Subsystems:

Idx|NQN                                                              |Trsp|Address      |SvcId|HFIs
---+-----------------------------------------------------------------+----+-------------+-----+----
1  |nqn.2022-12.org.nvmexpress.boot.poc:bremer.vagrant-nvmet.subsys02|tcp |192.168.49.10|4420 |1   

NBFT HFIs:

Idx|Trsp|PCI Addr  |MAC Addr         |DHCP|IP Addr       |Mask|Gateway |DNS         
---+----+----------+-----------------+----+--------------+----+--------+------------
1  |tcp |0:0:1.0   |52:54:00:b8:19:b9|yes |192.168.49.155|24  |0.0.0.0 |192.168.49.1

NBFT Discovery Controllers:

Idx|URI                           |NQN                                 
---+------------------------------+------------------------------------
1  |nvme+tcp://192.168.49.10:4420/|nqn.2014-08.org.nvmexpress.discovery
```